### PR TITLE
refact: file watcher, resolve -> join, @/access, error handler if no access.ts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: Node CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node_version: [8.x, 10.x, 12.x]
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node_version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node_version }}
+      - run: yarn
+      - run: yarn build
+      - run: yarn test --forceExit
+        env:
+          CI: true
+          HEADLESS: false
+          PROGRESS: none
+          NODE_ENV: test
+          NODE_OPTIONS: --max_old_space_size=4096
+

--- a/src/getAccessProviderContent.ts
+++ b/src/getAccessProviderContent.ts
@@ -1,11 +1,11 @@
 
-export default function (accessFilePath: string) {
+export default function () {
   return `\
 import React, { useMemo } from 'react';
 import { IRoute } from 'umi-types';
 import { useModel } from 'umi';
 import AccessContext, { AccessInstance } from './context';
-import accessFactory from '${accessFilePath}';
+import accessFactory from '@/access';
 
 const _routes = require('../router').routes;
 
@@ -55,7 +55,7 @@ interface Props {
 
 const AccessProvider: React.FC<Props> = props => {
   const { children } = props;
-  const { initialState, refresh, loading } = useModel('@@initialState');
+  const { initialState, loading } = useModel('@@initialState');
 
   const access = useMemo(() => accessFactory(initialState), [initialState]);
 
@@ -70,7 +70,7 @@ const AccessProvider: React.FC<Props> = props => {
     { value: access },
     children,
   );
-}
+};
 
 export default AccessProvider;
 `;

--- a/src/getContextContent.ts
+++ b/src/getContextContent.ts
@@ -1,8 +1,8 @@
 
-export default function(accessFilePath: string) {
+export default function() {
   return `\
 import React from 'react';
-import accessFactory from '${accessFilePath}';
+import accessFactory from '@/access';
 
 export type AccessInstance = ReturnType<typeof accessFactory>;
 

--- a/src/getRootContainerContent.ts
+++ b/src/getRootContainerContent.ts
@@ -1,10 +1,10 @@
 
-export default function(accessFilePath: string) {
+export default function() {
   return `\
 import React from 'react';
 import AccessProvider from './AccessProvider';
 
-export function rootContainer(container) {
+export function rootContainer(container: React.ReactNode) {
   return React.createElement(AccessProvider, null, container);
 }
 `;


### PR DESCRIPTION

改动点，

1. 监听 access.(j|t)s，变更时重新生成临时文件
2. code style
3. 生成的代码里用 `@/access` 代替绝对路径
4. 没有 access.ts 时的出错处理
5. 临时文件的 ts 类型问题
