### PR TITLE
feat: 确保 initial state 加载完后再继续渲染

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Umi plugin for access management.
 
 ## Prerequisites
 
-Before using this plugin, you need install and enable [@umijs/plugin-model](https://www.npmjs.com/package/@umijs/plugin-model) and [@umijs/plugin-initial-state](https://www.npmjs.com/package/@umijs/plugin-initial-state).
+Before using this plugin, you need install and enable [@umijs/plugin-initial-state](https://www.npmjs.com/package/@umijs/plugin-initial-state) and [@umijs/plugin-model](https://www.npmjs.com/package/@umijs/plugin-model).
 
 ## Install
 
@@ -25,14 +25,14 @@ Getting started in 3 steps.
 
 ### 1. Configure in `.umirc.js`
 
-**Caution**: `@umijs/plugin-access` must be **before** `@umijs/plugin-model`.
+**Caution**: `@umijs/plugin-access`, `@umijs/plugin-initial-state` and `@umijs/plugin-model` must be in this order.
 
 ```js
 export default {
   plugins: [
     ['@umijs/plugin-access'],
-    ['@umijs/plugin-model'],
     ['@umijs/plugin-initial-state'],
+    ['@umijs/plugin-model'],
   ],
 };
 ```
@@ -82,6 +82,10 @@ import { useAccess, Access } from 'umi';
 const PageA = props => {
   const { foo } = props;
   const access = useAcccess(); // members of access: canReadFoo, canUpdateFoo, canDeleteFoo
+
+  if (access.canReadFoo) {
+    // Do something...
+  }
 
   return (
     <div>

--- a/example/.umirc.ts
+++ b/example/.umirc.ts
@@ -7,7 +7,7 @@ export default {
   ],
   plugins: [
     join(__dirname, '..', require('../package').main || 'index.js'),
-    ['@umijs/plugin-model'],
     ['@umijs/plugin-initial-state'],
+    ['@umijs/plugin-model'],
   ],
 } as IConfig;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@testing-library/react": "^9.3.2",
     "@types/jest": "^24.0.23",
     "@types/node": "^12.12.11",
-    "@umijs/plugin-initial-state": "^0.1.0",
+    "@umijs/plugin-initial-state": "^0.2.0",
     "@umijs/plugin-model": "^0.1.0",
     "cross-env": "^6.0.3",
     "father-build": "^1.15.0",

--- a/src/utils/getAccessProviderContent.ts
+++ b/src/utils/getAccessProviderContent.ts
@@ -1,21 +1,20 @@
-
 export default function () {
   return `\
 import React, { useMemo } from 'react';
-import { IRoute } from 'umi-types';
 import { useModel } from 'umi';
-import AccessContext, { AccessInstance } from './context';
+import { IRoute } from 'umi-types';
 import accessFactory from '@/access';
-
-const _routes = require('../router').routes;
-
-type Routes = IRoute[];
+import AccessContext, { AccessInstance } from './context';
 
 if (typeof useModel !== 'function') {
   throw new Error('[plugin-access]: useModel is not a function, @umijs/plugin-initial-state is needed.')
 }
 
-function traverseModifyRoutes(routes: Routes, access: AccessInstance) {
+const _routes = require('../router').routes;
+
+type Routes = IRoute[];
+
+function traverseModifyRoutes(routes: Routes, access: AccessInstance = {}) {
   const resultRoutes: Routes = [].concat(routes as any);
   const notHandledRoutes: Routes = [];
 
@@ -55,15 +54,15 @@ interface Props {
 
 const AccessProvider: React.FC<Props> = props => {
   const { children } = props;
-  const { initialState, loading } = useModel('@@initialState');
+  const { initialState } = useModel('@@initialState');
 
   const access = useMemo(() => accessFactory(initialState), [initialState]);
 
-  _routes.splice(0, _routes.length, ...traverseModifyRoutes(_routes, access));
-
-  if (loading) {
-    return null; // ! 影响很大，需要确定要不要这么做，不这么做有没有更好的办法
+  if (process.env.NODE_ENV === 'development' && (access === undefined || access === null)) {
+    console.warn('[plugin-access]: the access instance created by access.ts(js) is nullish, maybe you need check it.');
   }
+
+  _routes.splice(0, _routes.length, ...traverseModifyRoutes(_routes, access));
 
   return React.createElement(
     AccessContext.Provider,


### PR DESCRIPTION
**问题：**

当 initial state 未加载完时，initial state 的初值是 `undefined`，如果在 access.ts 中对 initial 进行解构值会造成 crash。

**分析：**

initial state 与一般页面数据不同，可以认为整个应用都会依赖它加载完后才能进入应用逻辑，所以在加载完之前不应该继续渲染和创建 access 实例。

这样的话在 [plugin-initial-state](https://github.com/umijs/plugin-initial-state) 中应将初始 loading 状态设为 `true`，plugin-access 如果拿到 loading 为 `true` 则停止往下执行，直到 loading 完成后再创建 access 实例以及往下渲染。

**具体做法：**

增加一层 `InitialStatePasser` 确保 initial state 的加载和控制应用的执行渲染。