### PR TITLE
enhance: optimize reminding logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,59 +4,71 @@ import getContextContent from './utils/getContextContent';
 import getAccessProviderContent from './utils/getAccessProviderContent';
 import getAccessContent from './utils/getAccessContent';
 import getRootContainerContent from './utils/getRootContainerContent';
-import { checkIfHasDefaultExporting } from './utils';
+import { getScriptPath, checkIfHasDefaultExporting } from './utils';
 
 const ACCESS_DIR = 'plugin-access'; // plugin-access 插件创建临时文件的专有文件夹
 
-export default function(api: IApi) {
+interface Options {
+  integrated: boolean; // 表明当前插件是否被其它插件集成
+}
+
+const defaultOptions: Options = { integrated: false };
+
+export default function (api: IApi, opts: Options = defaultOptions) {
   const umiTmpDir = api.paths.absTmpDirPath;
   const srcDir = api.paths.absSrcPath;
   const accessTmpDir = join(umiTmpDir, ACCESS_DIR);
   const accessFilePath = join(srcDir, 'access');
 
   api.onGenerateFiles(() => {
-    const enableAccess = checkIfHasDefaultExporting(accessFilePath);
-
     // 判断 access 工厂函数存在并且 default 暴露了一个函数
-    if (!enableAccess) {
-      api.log.warn(
-        `[plugin-access]: access.js or access.ts file should be defined at srcDir and default exporting a factory function.`
-      );
+    if (checkIfHasDefaultExporting(accessFilePath)) {
+      // 创建 access 的 context 以便跨组件传递 access 实例
+      api.writeTmpFile(`${ACCESS_DIR}/context.ts`, getContextContent());
+
+      // 创建 AccessProvider，1. 生成 access 实例; 2. 遍历修改 routes; 3. 传给 context 的 Provider
+      api.writeTmpFile(`${ACCESS_DIR}/AccessProvider.ts`, getAccessProviderContent());
+
+      // 创建 access 的 hook
+      api.writeTmpFile(`${ACCESS_DIR}/access.ts`, getAccessContent());
+
+      // 生成 rootContainer 运行时配置
+      api.writeTmpFile(`${ACCESS_DIR}/rootContainer.ts`, getRootContainerContent());
+    } else {
+      // 只在插件处于集成模式，并且 access 文件不存在时，才不给出警告信息，其它情况下都认为 access 文件有问题
+      if (!(opts.integrated && !getScriptPath(accessFilePath))) {
+        api.log.warn(
+          `[plugin-access]: access.js or access.ts file should be defined at srcDir and default exporting a factory function.`
+        );
+      }
     }
-
-    // 创建 access 的 context 以便跨组件传递 access 实例
-    api.writeTmpFile(`${ACCESS_DIR}/context.ts`, getContextContent());
-
-    // 创建 AccessProvider，1. 生成 access 实例; 2. 遍历修改 routes; 3. 传给 context 的 Provider
-    api.writeTmpFile(`${ACCESS_DIR}/AccessProvider.ts`, getAccessProviderContent());
-
-    // 创建 access 的 hook
-    api.writeTmpFile(`${ACCESS_DIR}/access.ts`, getAccessContent());
-
-    // 生成 rootContainer 运行时配置
-    api.writeTmpFile(
-      `${ACCESS_DIR}/rootContainer.ts`,
-      enableAccess ? getRootContainerContent() : '/* keep file */',
-    );
   });
 
-  // 增加 rootContainer 运行时配置
-  // TODO: eliminate this workaround
-  api.addRuntimePlugin(join(umiTmpDir, '@tmp', ACCESS_DIR, 'rootContainer.ts'));
+  // * api.register() 不能在初始化之后运行
+  if (checkIfHasDefaultExporting(accessFilePath)) {
+    // 增加 rootContainer 运行时配置
+    // TODO: eliminate this workaround
+    api.addRuntimePlugin(join(umiTmpDir, '@tmp', ACCESS_DIR, 'rootContainer.ts'));
 
-  api.addUmiExports([
-    {
-      specifiers: ['useAccess', 'Access', 'AccessProps'],
-      source: join(accessTmpDir, 'access'),
-    },
-    {
-      specifiers: ['AccessInstance'],
-      source: join(accessTmpDir, 'context'),
-    },
-  ]);
+    api.addUmiExports([
+      {
+        specifiers: ['useAccess', 'Access', 'AccessProps'],
+        source: join(accessTmpDir, 'access'),
+      },
+      {
+        specifiers: ['AccessInstance'],
+        source: join(accessTmpDir, 'context'),
+      },
+    ]);
 
-  api.addPageWatcher([
-    `${accessFilePath}.ts`,
-    `${accessFilePath}.js`,
-  ]);
+    api.addPageWatcher([
+      `${accessFilePath}.ts`,
+      `${accessFilePath}.js`,
+    ]);
+  }
+
+  api.onOptionChange(newOpts => {
+    opts = newOpts || defaultOptions;
+    api.rebuildTmpFiles();
+  });
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,21 +1,22 @@
 import fs from 'fs';
 
-export function checkIfHasDefaultExporting(filepath: string): boolean {
-  let fileExist = false;
-  let realFilePath = '';
+export function getScriptPath(filepath: string): string {
+  let realFilePath: string = '';
   if (fs.existsSync(`${filepath}.ts`)) {
     realFilePath = `${filepath}.ts`;
-    fileExist = true;
   } else if (fs.existsSync(`${filepath}.js`)) {
     realFilePath = `${filepath}.js`;
-    fileExist = true;
   }
+  return realFilePath;
+}
 
-  if (!fileExist) {
+export function checkIfHasDefaultExporting(filepath: string): boolean {
+  const scriptPath = getScriptPath(filepath);
+  if (!scriptPath) {
     return false;
   }
 
-  const fileContent = fs.readFileSync(realFilePath, 'utf8');
+  const fileContent = fs.readFileSync(scriptPath, 'utf8');
   const validationRegExp = /(export\s*default)|(exports\.default)|(module.exports[\s\S]*default)|(module.exports[\s\n]*=)/m;
 
   return validationRegExp.test(fileContent);


### PR DESCRIPTION
**Changes:**

1. add `integrated` option to show if plugin-access is integrated by other plugin
2. when `integrated` is `true`, and access script is not exist, plugin-access won't output a warning, otherwise a warning displayed if access feature is not defined:

|"access" exist|`integrated` is `false`|`integrated` is `true`|
|--|--|--|
|N|✔|✗|
|Y|✔|✔|

"✔" means show warning, "✗" means not show warning.