### PR TITLE
chore: delete nodejs@8 engine in CI process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: [8.x, 10.x, 12.x]
+        node_version: [10.x, 12.x]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v1
@@ -24,4 +24,3 @@ jobs:
           PROGRESS: none
           NODE_ENV: test
           NODE_OPTIONS: --max_old_space_size=4096
-


### PR DESCRIPTION
`umi` 间接依赖的 `jsdom` 升级到了 16.0.0 版本，这个版本的 `jsdom` 依赖 nodejs 10 以上的版本，此外大部分开发者都可以或已经工作在 nodejs 10 以上的，因此将 nodejs@8 从 CI 流程中移除。