### PR TITLE
fix: typescript warn

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,10 +49,6 @@ export default function(api: IApi) {
       exportAll: true,
       source: api.winPath(join(accessTmpDir, 'access')),
     },
-    {
-      specifiers: ['AccessInstance'],
-      source: api.winPath(join(accessTmpDir, 'context')),
-    },
   ]);
 
   api.addPageWatcher([`${accessFilePath}.ts`, `${accessFilePath}.js`]);

--- a/src/utils/getAccessContent.ts
+++ b/src/utils/getAccessContent.ts
@@ -1,7 +1,9 @@
 export default function() {
   return `\
 import React, { useContext } from 'react';
-import AccessContext from './context';
+import AccessContext, { AccessInstance as AccessInstanceType } from './context';
+
+export type AccessInstance = AccessInstanceType;
 
 export const useAccess = () => {
   const access = useContext(AccessContext);


### PR DESCRIPTION
export AccessInstance from  'access.ts' as a type for avoid typescript warn.

![image](https://user-images.githubusercontent.com/1061968/72586798-e8301c00-392d-11ea-8382-8f3b75118e4d.png)
